### PR TITLE
Move to mpv-scroll-list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ This script allows you to search for keybinds, properties, options and commands 
 The search is case insensitive by default, and the script sends the filter directly to a lua string match function, so you can use patterns to get more complex filtering. For options and limitations see the [Queries](#queries) and [Flags](#flags) sections.
 
 ## Pages
-The search page will remain open until the esc key is pressed. When the search page is open the up and down arrow can be used to scroll through the results, and the left and right arrows can be used to pan horizontally to see any cut off values.
+The search pages will remain open until the esc key is pressed. When the page is open the up and down arrow can be used to scroll through the results, and the left and right arrows can be used to pan horizontally to see any cut off values.
 
-There are 4 main search pages:
+There are 4 main search pages, each page has its own independant state, and while open one can cycle between them in the below order:
 
 ### Keybinds
 ![keybinds_page](screenshots/keybindings_page.png)
@@ -30,19 +30,19 @@ The search page shows all of the command names in lavendar on the left. The foll
 
 Pressing keys 1-9 will load the command for that respective entry into console.lua, and print the arguments and their types to the console for reference. Compulsory arguments will have an exclamation mark before them.
 
-### Properties
-![property_page](screenshots/property_page.png)
-
-The properties page shows all of the properties, and their current values, for the current file. Only the property name is included in the search. Note that the property list contains most options as well.
-
-The search page simply contains the property name on the left, followed by it's current value (if it has one).
-
 ### Options
 ![option_page](screenshots/option_page.png)
 
 The options page is for searching options that can be set on the commandline or through mpv.conf. Most of these options have matching properties. The script searches the option name, as well as any choices that are available.
 
 The option page contains the option name in lavendar, directly followed by the option type in yellow. The cyan entry is the current value of the option, if available, and the yellow is the default option value. The green value shows different information depending on the option type; if the option is a float, integer, double, aspect, or bytesize, then the valid option range is displayed; if the option is a choice, then the valid choices are listed.
+
+### Properties
+![property_page](screenshots/property_page.png)
+
+The properties page shows all of the properties, and their current values, for the current file. Only the property name is included in the search. Note that the property list contains most options as well.
+
+The search page simply contains the property name on the left, followed by it's current value (if it has one).
 
 ## Keybinds
 
@@ -52,7 +52,6 @@ The default keybinds are listed below, these can be overwritten using input.conf
     Ctrl+f12            script-binding search-commands
     Shift+f12           script-binding search-properties
     Alt+f12             script-binding search-options
-    Ctrl+Shift+Alt+f12  script-binding search-all
 
 In addition the following keybinds are dynamically created when the search page is open, these cannot currently be changed:
 
@@ -61,6 +60,11 @@ In addition the following keybinds are dynamically created when the search page 
     up              scrolls the page up
     left            pans the whole search page left
     right           pans the whole search page right
+    Shift+left      open prev page
+    Shift+right     open next page
+    Ctrl+left       open prev page and run latest search
+    Ctrl+right      open next page and run latest search
+    Ctrl+enter      re-run latest search on current page
     enter           see jumplist
     1-9             see jumplist
 
@@ -84,14 +88,12 @@ Here is an example of a query to search keybinds for 'del':
 
     script-message search_page/input key$ "cycle vid"
 
-Query types can also be combined, i.e. `key$cmd$`, to search multiple categories at once.
 The valid query types are as follows:
 
     key$    searches keybindings
     cmd$    searches command
     prop$   searches properties
     opt$    searches options
-    all$    searches all
 
 Sending a query message without any arguments (or with only the type argument) will reopen the last search page. Sending a query with an empty string `""` will show all results for the selected category.
 

--- a/search-page.lua
+++ b/search-page.lua
@@ -135,18 +135,18 @@ end
 
 --loads the results up onto the screen
 --is run for every scroll operation as well
-function load_results()
+local function load_results()
     list.global_style = "{\\pos("..search.posX..",10)\\an7}"
     list:update()
     return
 end
 
-function pan_right()
+local function pan_right()
     search.posX = search.posX - o.pan_speed
     load_results()
 end
 
-function pan_left()
+local function pan_left()
     search.posX = search.posX + o.pan_speed
     if search.posX > 15 then
         search.posX = 15
@@ -156,7 +156,7 @@ function pan_left()
 end
 
 --handles the search queries
-function compare(str, keyword, flags)
+local function compare(str, keyword, flags)
     if not flags then
         return str:lower():find(keyword:lower())
     end
@@ -184,14 +184,14 @@ function compare(str, keyword, flags)
     end
 end
 
-function return_spaces(string_len, width)
+local function return_spaces(string_len, width)
     local num_spaces = width - string_len
     if num_spaces < 2 then num_spaces = 2 end
     return string.rep(" ", num_spaces)
 end
 
 --search keybinds
-function search_keys(keyword, flags)
+local function search_keys(keyword, flags)
     local keys = mp.get_property_native('input-bindings')
     local keybound = {}
 
@@ -269,8 +269,8 @@ function search_keys(keyword, flags)
 end
 
 --search commands
-function search_commands(keyword, flags)
-    commands = mp.get_property_native('command-list')
+local function search_commands(keyword, flags)
+    local commands = mp.get_property_native('command-list')
 
     for _,command in ipairs(commands) do
         if
@@ -307,7 +307,7 @@ function search_commands(keyword, flags)
     end
 end
 
-function search_options(keyword, flags)
+local function search_options(keyword, flags)
     local options = mp.get_property_native('options')
 
     for _,option in ipairs(options) do
@@ -354,7 +354,7 @@ function search_options(keyword, flags)
     end
 end
 
-function search_property(keyword, flags)
+local function search_property(keyword, flags)
     local properties = mp.get_property_native('property-list', {})
 
     for _,property in ipairs(properties) do

--- a/search-page.lua
+++ b/search-page.lua
@@ -305,7 +305,7 @@ function KEYBINDS:search(keyword, flags)
             comment = self.ass_escape(comment)
 
             --appends the result to the list
-            table.insert(self.list, {
+            self:insert({
                 type = "key",
                 ass = o.ass_allkeybindresults .. o.ass_key .. key .. o.ass_section .. section .. o.ass_cmdkey .. cmd .. o.ass_comment .. comment,
                 key = keybind.key,
@@ -323,7 +323,7 @@ function KEYBINDS:search(keyword, flags)
     end
 
     --does a second pass of the results and greys out any overwritten keys
-    for _,v in ipairs(self.list) do
+    for _,v in self:ipairs() do
         if keybound[v.key] and keybound[v.key].cmd ~= v.cmd then
             v.ass = "{\\alpha&H80&}"..v.ass.."{\\alpha&H00&}"
         end
@@ -357,7 +357,7 @@ function COMMANDS:search(keyword, flags)
                 arg_string = arg_string .. " " .. arg.name .. o.ass_argtype.." ("..arg.type..") "
             end
 
-            table.insert(self.list, {
+            self:insert({
                 type = "command",
                 ass = o.ass_cmd..self.ass_escape(cmd)..return_spaces(cmd:len(), 20)..arg_string,
                 funct = function()
@@ -410,7 +410,7 @@ function OPTIONS:search(keyword, flags)
 
             local result = o.ass_options..self.ass_escape(option).."  "..o.ass_optionstype..type..first_space..o.ass_optvalue..self.ass_escape(opt_value)
             result = result..second_space..o.ass_optionsdefault..self.ass_escape(default)..third_space..o.ass_optionsspec..self.ass_escape(options_spec)
-            table.insert(self.list, {
+            self:insert({
                 type = "option",
                 ass = result,
                 funct = function()
@@ -427,7 +427,7 @@ function PROPERTIES:search(keyword, flags)
 
     for _,property in ipairs(properties) do
         if compare(property, keyword, flags) then
-            table.insert(self.list, {
+            self:insert({
                 type = "property",
                 ass = o.ass_properties..self.ass_escape(property)..return_spaces(property:len(), 40)..o.ass_propertycurrent..self.ass_escape(mp.get_property(property, "")),
                 funct = function()
@@ -443,7 +443,7 @@ end
 function list_meta:run_search(keyword, flags)
     self.latest_search.keyword = keyword
     self.latest_search.flags = flags
-    self.list = {}
+    self:clear()
     self.keyword = keyword
     self.flags = flags
 

--- a/search-page.lua
+++ b/search-page.lua
@@ -100,7 +100,7 @@ opt.read_options(o, "search_page")
 
 package.path = (mp.get_opt("scroll_list-directory") or mp.command_native({'expand-path', '~~/scripts'})) .. '/?.lua;' .. package.path
 local _list = require 'scroll-list'
-local list_meta = getmetatable( _list ).__index
+local list_meta = getmetatable( _list ).__scroll_list
 
 local osd_display = mp.get_property_number('osd-duration')
 
@@ -158,7 +158,7 @@ local function create_page(type, t)
         {"DOWN", "down_page", function() temp:scroll_down() end, {repeatable = true}},
         {"UP", "up_page", function() temp:scroll_up() end, {repeatable = true}},
         {"ESC", "close_overlay", function() temp:close() end, {}},
-        -- {"ENTER", "run_current", function() temp.list[temp.selected].funct() end, {}},
+        {"ENTER", "run_current", function() temp[temp.selected].funct() end, {}},
         {"LEFT", "pan_left", function() temp:pan_left() end, {repeatable = true}},
         {"RIGHT", "pan_right", function() temp:pan_right() end, {repeatable = true}},
         {"Shift+LEFT", "page_left", function() temp:page_left() end, {}},

--- a/search-page.lua
+++ b/search-page.lua
@@ -98,7 +98,7 @@ local o = {
 
 opt.read_options(o, "search_page")
 
-package.path = (mp.get_opt("scroll_list-directory") or mp.command_native({'expand-path', '~~/scripts'})) .. '/?.lua;' .. package.path
+package.path = mp.command_native({'expand-path', '~~/scripts'}) .. '/?.lua;' .. package.path
 local _list = require 'scroll-list'
 local list_meta = getmetatable( _list ).__scroll_list
 

--- a/search-page.lua
+++ b/search-page.lua
@@ -256,7 +256,6 @@ end
 
 --search keybinds
 function KEYBINDS:search(keyword, flags)
-    local list = self
     local keys = mp.get_property_native('input-bindings')
     local keybound = {}
 
@@ -300,23 +299,23 @@ function KEYBINDS:search(keyword, flags)
                 comment = return_spaces(key:len()+section:len()+cmd:len(),60) .. "#" .. keybind.comment
             end
 
-            key = list.ass_escape(key)
-            section = list.ass_escape(section)
-            cmd = list.ass_escape(cmd)
-            comment = list.ass_escape(comment)
+            key = self.ass_escape(key)
+            section = self.ass_escape(section)
+            cmd = self.ass_escape(cmd)
+            comment = self.ass_escape(comment)
 
             --appends the result to the list
-            table.insert(list.list, {
+            table.insert(self.list, {
                 type = "key",
                 ass = o.ass_allkeybindresults .. o.ass_key .. key .. o.ass_section .. section .. o.ass_cmdkey .. cmd .. o.ass_comment .. comment,
                 key = keybind.key,
                 cmd = keybind.cmd,
                 funct = function()
-                    list:close()
+                    self:close()
                     mp.command(keybind.cmd)
 
                     mp.add_timeout(osd_display/1000, function()
-                        list:open()
+                        self:open()
                     end)
                 end
             })
@@ -324,7 +323,7 @@ function KEYBINDS:search(keyword, flags)
     end
 
     --does a second pass of the results and greys out any overwritten keys
-    for _,v in ipairs(list.list) do
+    for _,v in ipairs(self.list) do
         if keybound[v.key] and keybound[v.key].cmd ~= v.cmd then
             v.ass = "{\\alpha&H80&}"..v.ass.."{\\alpha&H00&}"
         end
@@ -335,7 +334,6 @@ end
 
 --search commands
 function COMMANDS:search(keyword, flags)
-    local list = self
     local commands = mp.get_property_native('command-list')
 
     for _,command in ipairs(commands) do
@@ -359,12 +357,12 @@ function COMMANDS:search(keyword, flags)
                 arg_string = arg_string .. " " .. arg.name .. o.ass_argtype.." ("..arg.type..") "
             end
 
-            table.insert(list.list, {
+            table.insert(self.list, {
                 type = "command",
-                ass = o.ass_cmd..list.ass_escape(cmd)..return_spaces(cmd:len(), 20)..arg_string,
+                ass = o.ass_cmd..self.ass_escape(cmd)..return_spaces(cmd:len(), 20)..arg_string,
                 funct = function()
                     mp.commandv('script-message-to', 'console', 'type', command.name .. " ")
-                    list:close()
+                    self:close()
                     msg.info("")
                     msg.info(result_no_ass)
                 end
@@ -374,7 +372,6 @@ function COMMANDS:search(keyword, flags)
 end
 
 function OPTIONS:search(keyword, flags)
-    local list = self
     local options = mp.get_property_native('options')
 
     for _,option in ipairs(options) do
@@ -411,14 +408,14 @@ function OPTIONS:search(keyword, flags)
                 options_spec = "    [ "..mp.get_property_number('option-info/'..option..'/min', "").."  -  ".. mp.get_property_number("option-info/"..option..'/max', "").." ]"
             end
 
-            local result = o.ass_options..list.ass_escape(option).."  "..o.ass_optionstype..type..first_space..o.ass_optvalue..list.ass_escape(opt_value)
-            result = result..second_space..o.ass_optionsdefault..list.ass_escape(default)..third_space..o.ass_optionsspec..list.ass_escape(options_spec)
-            table.insert(list.list, {
+            local result = o.ass_options..self.ass_escape(option).."  "..o.ass_optionstype..type..first_space..o.ass_optvalue..self.ass_escape(opt_value)
+            result = result..second_space..o.ass_optionsdefault..self.ass_escape(default)..third_space..o.ass_optionsspec..self.ass_escape(options_spec)
+            table.insert(self.list, {
                 type = "option",
                 ass = result,
                 funct = function()
                     mp.commandv('script-message-to', 'console', 'type', 'set '.. option .. " ")
-                    list:close()
+                    self:close()
                 end
             })
         end
@@ -426,29 +423,30 @@ function OPTIONS:search(keyword, flags)
 end
 
 function PROPERTIES:search(keyword, flags)
-    local list = self
     local properties = mp.get_property_native('property-list', {})
 
     for _,property in ipairs(properties) do
         if compare(property, keyword, flags) then
-            table.insert(list.list, {
+            table.insert(self.list, {
                 type = "property",
-                ass = o.ass_properties..list.ass_escape(property)..return_spaces(property:len(), 40)..o.ass_propertycurrent..list.ass_escape(mp.get_property(property, "")),
+                ass = o.ass_properties..self.ass_escape(property)..return_spaces(property:len(), 40)..o.ass_propertycurrent..self.ass_escape(mp.get_property(property, "")),
                 funct = function()
                     mp.commandv('script-message-to', 'console', 'type', 'print-text ${'.. property .. "} ")
-                    list:close()
+                    self:close()
                 end
             })
         end
     end
 end
 
+--prepares the page for a search
 function list_meta:run_search(keyword, flags)
     self.latest_search.keyword = keyword
     self.latest_search.flags = flags
     self.list = {}
     self.keyword = keyword
     self.flags = flags
+
     self:search( keyword, create_set(flags) )
     self:update()
 end
@@ -496,8 +494,4 @@ end)
 
 mp.add_key_binding("Alt+f12", "search-options", function()
     mp.commandv('script-message-to', 'console', 'type', 'script-message search_page/input opt$ ')
-end)
-
-mp.add_key_binding("Alt+Shift+Ctrl+f12", "search-all", function ()
-    mp.commandv('script-message-to', 'console', 'type', 'script-message search_page/input all$ ')
 end)


### PR DESCRIPTION
Changes script to use the mpv-scroll-list API
Also significantly changes the script to track each
search type in separate pages which can be managed
individually.

- [X] Change native list implementation to scroll-list
- [X] Change single list system to object based pages
- [x] Update documentation