### PR TITLE
Add note about input prompt scaling, and add options to change the key to start and restart searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The script messages allow you to specify which page to open, valid values are `k
 
 ### Dynamic Keybinds
 
-In addition the following keybinds are dynamically created when the search page is open, these cannot currently be changed:
+In addition the following keybinds are dynamically created when the search page is open. `f12` and `Shift+f12` can be changed in [search_page.conf](search_page.conf). The others cannot currently be changed:
 
     f12             opens search input
     Shift+f12       opens advanced search input

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ By default the script will escape these special characters to make searches more
 
 The full list of options, and their defaults are shown in [search_page.conf](search_page.conf).
 
+The scale of the input prompt can be changed with this setting in the `mpv.conf`:
+
+```txt
+script-opts-append=user_input-scale=1
+```
+
 ## Future Plans
 
 Some ideas for future functionality:

--- a/search-page.lua
+++ b/search-page.lua
@@ -60,6 +60,10 @@ local o = {
     --number of pixels to pan on each click
     --this refers to the horizontal panning
     pan_speed = 100,
+    
+    --these change the default keybindings to open a search, as well as to restart a search, while a page is open
+    keybind_open_search = "f12",
+    keybind_open_flag_search = "Shift+f12",
 
     --all colour options
     ass_header = "{\\c&H00ccff&\\fs40\\b500\\q2\\fnMonospace}",
@@ -190,8 +194,8 @@ local function create_page(type, t)
         {"Ctrl+LEFT", "page_left_search", function() temp:move_page(-1, true) end, {}},
         {"Ctrl+RIGHT", "page_right_search", function() temp:move_page(1, true) end, {}},
         {"Ctrl+ENTER", "run_latest", function() temp:run_search(LATEST_SEARCH.keyword, LATEST_SEARCH.flags) end, {}},
-        {"f12", "open_search", function() temp:get_input(false) end, {}},
-        {"Shift+f12", "open_flag_search", function() temp:get_input(true) end, {}}
+        {o.keybind_open_search, "open_search", function() temp:get_input(false) end, {}},
+        {o.keybind_open_flag_search, "open_flag_search", function() temp:get_input(true) end, {}}
     }
     return temp
 end
@@ -502,7 +506,7 @@ function list_meta:run_search()
 end
 
 function list_meta:open_wrapper(advanced)
-    if self.keyword == nil then self.empty_text = "Press f12 to enter search query" end
+    if self.keyword == nil then self.empty_text = "Enter a new search query" end
     self:open()
     if self.keyword == nil then self:get_input(advanced) end
 end
@@ -546,11 +550,11 @@ function list_meta:get_input(get_flags)
     coroutine_resume_err(co)
 end
 
-mp.add_key_binding("f12", "open-search-page", function()
+mp.add_key_binding(o.keybind_open_search, "open-search-page", function()
     CURRENT_PAGE:open_wrapper()
 end)
 
-mp.add_key_binding("Shift+f12", "open-search-page/advanced", function()
+mp.add_key_binding(o.keybind_open_flag_search, "open-search-page/advanced", function()
     CURRENT_PAGE:open_wrapper(true)
 end)
 

--- a/search_page.conf
+++ b/search_page.conf
@@ -8,6 +8,10 @@ max_list=26
 #this refers to the horizontal panning
 pan_speed=100
 
+#these change the default keybindings to open a search, as well as to restart a search, while a page is open
+keybind_open_search=f12
+keybind_open_flag_search=Shift+f12
+
 
 ##############################################################
 # The below options are very advanced, it is mostly to provide


### PR DESCRIPTION
This PR has two commits:

The first one adds only a small note to the readme how the input prompt text scaling can be changed. This setting seems very important for high DPI displays. I have a UHD monitor and scale=1 is not readable and scale=7 comfortable.

I have the keybind to open the script on Ctrl+f instead of f12, because it is more intuitive and better for laptop keyboards and fancy keyboards, which have the F-keys hidden behind a second layer. Changing the keybinding only in `input.conf` leads to the issue, that restarting a search when a page is already opened is un-intuitive. So the second commit changes only a few lines of the code to allow options to change the f12 default.

I also changed the text `Press f12 to enter search query` to `Enter a new search query`, because this text is usually shown after the keybind has been pressed and is therefore misleading.
