### PR TITLE
feat(search-page): extend search to command arguments and property values, display more choices, and allow list wrapping

### DIFF
--- a/search-page.lua
+++ b/search-page.lua
@@ -366,26 +366,27 @@ function COMMANDS:search(keyword, flags)
     local commands = mp.get_property_native('command-list')
 
     for _,command in ipairs(commands) do
+        local cmd = command.name
+        local result_no_ass = cmd
+
+        local arg_string = ""
+
+        for _,arg in ipairs(command.args) do
+            if arg.optional then
+                arg_string = arg_string .. o.ass_optargs
+                result_no_ass = result_no_ass .. " "
+            else
+                result_no_ass = result_no_ass .. " !"
+                arg_string = arg_string .. o.ass_args
+            end
+            result_no_ass = result_no_ass .. arg.name .. "("..arg.type..") "
+            arg_string = arg_string .. " " .. arg.name .. o.ass_argtype.." ("..arg.type..") "
+        end
+        
         if
         compare(command.name, keyword, flags)
+        or compare(result_no_ass, keyword, flags)
         then
-            local cmd = command.name
-            local result_no_ass = cmd
-
-            local arg_string = ""
-
-            for _,arg in ipairs(command.args) do
-                if arg.optional then
-                    arg_string = arg_string .. o.ass_optargs
-                    result_no_ass = result_no_ass .. " "
-                else
-                    result_no_ass = result_no_ass .. " !"
-                    arg_string = arg_string .. o.ass_args
-                end
-                result_no_ass = result_no_ass .. arg.name .. "("..arg.type..") "
-                arg_string = arg_string .. " " .. arg.name .. o.ass_argtype.." ("..arg.type..") "
-            end
-
             self:insert({
                 type = "command",
                 ass = o.ass_cmd..self.ass_escape(cmd)..return_spaces(cmd:len(), 20)..arg_string,

--- a/search-page.lua
+++ b/search-page.lua
@@ -57,6 +57,8 @@ local o = {
     --there seems to be a significant performance hit from having lots of text off the screen
     max_list = 20,
 
+    wrap = false,
+
     --number of pixels to pan on each click
     --this refers to the horizontal panning
     pan_speed = 100,
@@ -108,6 +110,7 @@ list_meta.wrapper_style = o.ass_footer
 list_meta.indent = [[\h\h\h]]
 list_meta.num_entries = o.max_list
 list_meta.empty_text = "no results"
+list_meta.wrap = o.wrap
 
 local CURRENT_PAGE = nil
 local LATEST_SEARCH = {

--- a/search-page.lua
+++ b/search-page.lua
@@ -456,10 +456,15 @@ function PROPERTIES:search(keyword, flags)
     local properties = mp.get_property_native('property-list', {})
 
     for _,property in ipairs(properties) do
-        if compare(property, keyword, flags) then
+        local values = mp.get_property(property, "")
+        
+        if
+        compare(property, keyword, flags)
+        or compare(values, keyword, flags)
+        then
             self:insert({
                 type = "property",
-                ass = o.ass_properties..self.ass_escape(property)..return_spaces(property:len(), 40)..o.ass_propertycurrent..self.ass_escape(mp.get_property(property, "")),
+                ass = o.ass_properties..self.ass_escape(property)..return_spaces(property:len(), 40)..o.ass_propertycurrent..self.ass_escape(values),
                 funct = function()
                     mp.commandv('script-message-to', 'console', 'type', 'print-text ${'.. property .. "} ")
                     self:close()

--- a/search-page.lua
+++ b/search-page.lua
@@ -428,14 +428,14 @@ function OPTIONS:search(keyword, flags)
 
             local options_spec = ""
 
-            if type == "Choice" then
-                options_spec = "    [ " .. choices .. ' ]'
-            elseif type == "Integer"
+            if type == "Integer"
             or type == "ByteSize"
             or type == "Float"
             or type == "Aspect"
             or type == "Double" then
                 options_spec = "    [ "..mp.get_property_number('option-info/'..option..'/min', "").."  -  ".. mp.get_property_number("option-info/"..option..'/max', "").." ]"
+            elseif choices ~= "" then
+                options_spec = "    [ " .. choices .. ' ]'
             end
 
             local result = o.ass_options..self.ass_escape(option).."  "..o.ass_optionstype..type..first_space..o.ass_optvalue..self.ass_escape(opt_value)


### PR DESCRIPTION
This PR consists of several new improvements.

- The search matches command arguments and their types, as well as property values.
- Display choices for more options, including options of type "Object settings list" (e.g. vo, ao, vf, af).
- Allow list wrapping in search results (set `wrap=yes` in search-page.conf to enable).

For example, we can search for commands that take a "filename" argument, 
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/45d3ec74-6412-496e-aa53-ab9fb9f556d5" />

or commands that take a "time" type argument,
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/dfa16f76-126f-4113-98ce-8849fc26fc5f" />

or properties with a value containing "7z",
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/55cd146c-5001-46fb-8979-57415b3422a8" />

and the choices for "af" which were previously missing, are now displayed correctly. 
<img width="1920" height="991" alt="image" src="https://github.com/user-attachments/assets/8b2073f0-4224-45a2-b772-d0b691d1569d" />
